### PR TITLE
v0.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ cmake_minimum_required(VERSION 3.21)
 # TODO: more robust install
 
 project(guardfw
-        VERSION 0.0.1
-        DESCRIPTION "templated C++ wrapper around posix functions for proper error handling"
-        HOMEPAGE_URL "https://simon.gleissner.de"
+        VERSION 0.0.2
+        DESCRIPTION "Templated C++ wrapper around Linux API functions for proper error handling."
+        HOMEPAGE_URL "https://guardfw.de"
         LANGUAGES CXX
         )
 
@@ -38,9 +38,10 @@ add_compile_options(
         -Wall
         -Wextra
         -Wpedantic
+        -Wconversion
+        -Wno-terminate
         -Werror
         -O3
-        -Wno-terminate
 )
 
 if (COMPILE_COVERAGE)
@@ -52,6 +53,7 @@ set(public_headers
         src/guardfw/file_descriptor.hpp
         src/guardfw/guard.hpp
         src/guardfw/guard_event.hpp
+        src/guardfw/guard_file.hpp
         src/guardfw/guard_timer.hpp
         src/guardfw/traits.hpp
         src/guardfw/version.hpp
@@ -68,18 +70,21 @@ set(public_headers
         )
 
 set(library_sources
+        src/exceptions.cpp
         src/guard_event.cpp
+        src/guard_file.cpp
         src/guard_timer.cpp
         )
 
 set(test_sources
         src/tests/test_version.cpp
         src/tests/test_wrapper.cpp
+        src/tests/test_file.cpp
         )
 
 add_library(guardfw SHARED
         ${library_sources}
-        #        ${public_headers}
+        # ${public_headers}
         )
 
 add_library(guardfw-static STATIC

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Simon Gleissner
+Copyright (c) 2022 Simon Gleissner <simon@gleissner.de>, http://guardfw.de
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # GuardFW
 
-templated C++ wrapper around posix functions for proper error handling
+Templated C++ wrapper around Linux API functions for proper error handling.

--- a/TODO
+++ b/TODO
@@ -1,3 +1,6 @@
 - switch to gcc-13, as soon GitHub runner image supports it.
 - wrapper.hpp: change throw_function() to make usage of std::format().
 - re-enable SonarQube, as soon as its support C++23.
+- add static_assert type check for template name_of() in traits.hpp
+- switch to C++20 modules
+- use CPack for package RPM files

--- a/config.hpp.in
+++ b/config.hpp.in
@@ -1,11 +1,11 @@
-/*
- * guardfw/config.hpp
- *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>, https://simon.gleissner.de
- *
- * This file is distributed under the MIT license, see file LICENSE.
+/**
+ * Auto-generated version numbers.
  *
  * This is a generated file, do not edit!
+ *
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once

--- a/libguardfw.pc.in
+++ b/libguardfw.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: libguardfw
 URL: http://www.concurrentfw.de
-Description: templated C++ wrapper around posix functions for proper error handling
+Description: Templated C++ wrapper around Linux API functions for proper error handling.
 Version: @PROJECT_VERSION@
 Requires: 
 Libs: -L${libdir} -lguardfw

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=sgleissner
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=GuardFW
-sonar.projectVersion=0.0.1
+sonar.projectVersion=0.0.2
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src/

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -1,0 +1,32 @@
+/*
+ * Exception for failed Linux API & POSIX calls.
+ *
+ * The WrapperError exception is based on std::system_error and contains both the name of the
+ * failed wrapped API call and the position of the failed call (probably of the wrapper call).
+ *
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
+ */
+
+#include <sstream>
+
+#include <guardfw/exceptions.hpp>
+
+namespace GuardFW
+{
+
+std::string WrapperError::build_what(
+	int error, const std::string_view& wrapped_function_name, const std::source_location& location
+)
+{
+	std::ostringstream what;
+	what << "In function '" << location.function_name()		// probably ContextPosix<>::wrapper<>() or guard
+		 << "' in file '" << location.file_name()			// probably wrapped_*.hpp or guard_*.cpp
+		 << "' at line " << location.line()					// probably in wrapped_*.hpp or guard_*.cpp
+		 << ": wrapped call to '" << wrapped_function_name	// wrapped POSIX function name
+		 << "()' failed with error " << error;				// error number
+	return std::move(what).str();
+}
+
+}  //  namespace GuardFW

--- a/src/guard_event.cpp
+++ b/src/guard_event.cpp
@@ -1,9 +1,13 @@
-/*
- * guard_event.cpp
+/**
+ * Guard class for wrapping the file descriptor of eventfd kernel objects and providung an API.
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * A guard class encapsulates the handle for a kernel object (here for eventfd events).
+ * This derived class provides opening and closing in constructor & destructor
+ * and the rest of the API as member functions.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #include <cstdint>
@@ -11,7 +15,6 @@
 #include <utility>
 
 #include <guardfw/guard_event.hpp>
-
 #include <guardfw/wrapped_eventfd.hpp>
 #include <guardfw/wrapped_unistd.hpp>
 
@@ -28,7 +31,7 @@ GuardEvent::GuardEvent(GuardEvent&& move)
 
 GuardEvent::~GuardEvent()
 {
-	close_on_destruction<GuardFW::close_ignore_eintr>();  // may throw
+	close_on_destruction<GuardFW::close>();	 // may throw
 }
 
 uint64_t GuardEvent::get_counter() const

--- a/src/guard_file.cpp
+++ b/src/guard_file.cpp
@@ -1,0 +1,150 @@
+/**
+ * Guard class for wrapping the file descriptor of file kernel objects and providung an API.
+ *
+ * A guard class encapsulates the handle for a kernel object (here files on the file system).
+ * This derived class provides opening and closing in constructor & destructor
+ * and the rest of the API as member functions.
+ *
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
+ */
+
+
+#include <guardfw/guard_file.hpp>
+#include <guardfw/wrapped_fnctl.hpp>
+#include <guardfw/wrapped_ioctl.hpp>
+#include <guardfw/wrapped_unistd.hpp>
+
+namespace GuardFW
+{
+
+GuardFile::GuardFile(  // Constructor wrapper for ::open() without mode parameter
+	const char* pathname,
+	Flags flags,
+	const std::source_location& source_location
+)
+: Guard(GuardFW::open(pathname, flags(), source_location))
+{}
+
+GuardFile::GuardFile(  // Constructor wrapper for ::open() with mode parameter
+	const char* pathname,
+	Flags flags,
+	Mode mode,
+	const std::source_location& source_location
+)
+: Guard(GuardFW::open(pathname, flags(), mode(), source_location))
+{}
+
+GuardFile::GuardFile(  // Constructor wrapper for ::creat()
+	const char* pathname,
+	Mode mode,
+	const std::source_location& source_location
+)
+: Guard(GuardFW::creat(pathname, mode(), source_location))
+{}
+
+GuardFile::GuardFile(  // Constructor wrapper for ::openat() without mode parameter
+	FileDescriptor dirfd,
+	const char* pathname,
+	Flags flags,
+	const std::source_location& source_location
+)
+: Guard(GuardFW::openat(dirfd, pathname, flags(), source_location))
+{}
+
+GuardFile::GuardFile(  // Constructor wrapper for ::openat() with mode parameter
+	FileDescriptor dirfd,
+	const char* pathname,
+	Flags flags,
+	Mode mode,
+	const std::source_location& source_location
+)
+: Guard(GuardFW::openat(dirfd, pathname, flags(), mode(), source_location))
+{}
+
+GuardFile::~GuardFile()	 // Destructor wrapper for ::close()
+{
+	close_on_destruction<GuardFW::close>();	 // may throw
+}
+
+void GuardFile::ioctl_noretval(	 // wrapper for ::ioctl() without return value
+	unsigned long request,
+	void* ptr,
+	const std::source_location& source_location
+)
+{
+	GuardFW::ioctl_noretval(handle, request, ptr, source_location);
+}
+
+[[nodiscard]] int GuardFile::ioctl_retval(	// wrapper for ::ioctl() with return value
+	unsigned long request,
+	void* ptr,
+	const std::source_location& source_location
+)
+{
+	return GuardFW::ioctl_retval(handle, request, ptr, source_location);
+}
+
+[[nodiscard]] size_t GuardFile::read(  // wrapper for ::read() without blocking prevention
+	void* buf,
+	size_t count,
+	const std::source_location& source_location
+)
+{
+	return GuardFW::read(handle, buf, count, source_location);
+}
+
+[[nodiscard]] std::optional<size_t> GuardFile::read_nonblock(  // wrapper for ::read() with blocking prevention
+	void* buf,
+	size_t count,
+	const std::source_location& source_location
+)
+{
+	return GuardFW::read_nonblock(handle, buf, count, source_location);
+}
+
+[[nodiscard]] size_t GuardFile::write(	// wrapper for ::write() without blocking prevention
+	void* buf,
+	size_t count,
+	const std::source_location& source_location
+)
+{
+	return GuardFW::write(handle, buf, count, source_location);
+}
+
+[[nodiscard]] std::optional<size_t> GuardFile::write_nonblock(	// wrapper for ::write() with blocking prevention
+	void* buf,
+	size_t count,
+	const std::source_location& source_location
+)
+{
+	return GuardFW::write_nonblock(handle, buf, count, source_location);
+}
+
+void GuardFile::syncfs(	 // wrapper for ::syncfs()
+	const std::source_location& source_location
+)
+{
+	GuardFW::syncfs(handle, source_location);
+}
+
+[[nodiscard]] off_t GuardFile::lseek(  // wrapper for ::lseek
+	off_t offset,
+	int whence,
+	const std::source_location& source_location
+)
+{
+	return GuardFW::lseek(handle, offset, whence, source_location);
+}
+
+[[nodiscard]] off64_t GuardFile::lseek64(  // wrapper for ::lseek64
+	off64_t offset,
+	int whence,
+	const std::source_location& source_location
+)
+{
+	return GuardFW::lseek64(handle, offset, whence, source_location);
+}
+
+}  // namespace GuardFW

--- a/src/guard_timer.cpp
+++ b/src/guard_timer.cpp
@@ -1,9 +1,13 @@
-/*
- * guard_timer.cpp
+/**
+ * Guard class for wrapping the file descriptor of timerfd kernel objects and providung an API.
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * A guard class encapsulates the handle for a kernel object (here for timerfd timers).
+ * This derived class provides opening and closing in constructor & destructor
+ * and the rest of the API as member functions.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #include <cstdint>
@@ -27,7 +31,7 @@ GuardTimer::GuardTimer(GuardTimer&& move)
 
 GuardTimer::~GuardTimer()
 {
-	close_on_destruction<GuardFW::close_ignore_eintr>();  // may throw
+	close_on_destruction<GuardFW::close>();	 // may throw
 }
 
 uint64_t GuardTimer::get_expirations() const
@@ -39,7 +43,7 @@ uint64_t GuardTimer::get_expirations() const
 
 void GuardTimer::set_expirations(uint64_t expirations) const
 {
-	GuardFW::ioctl(handle, TFD_IOC_SET_TICKS, &expirations);
+	GuardFW::ioctl_noretval(handle, TFD_IOC_SET_TICKS, &expirations);
 }
 
 void GuardTimer::set_time(int flags, const struct itimerspec& new_value, struct itimerspec& old_value) const

--- a/src/guardfw/exceptions.hpp
+++ b/src/guardfw/exceptions.hpp
@@ -1,0 +1,39 @@
+/*
+ * Exception for failed Linux API & POSIX calls.
+ *
+ * The WrapperError exception is based on std::system_error and contains both the name of the
+ * failed wrapped API call and the position of the failed call (probably of the wrapper call).
+ *
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
+ */
+
+#pragma once
+#ifndef GUARDFW_EXCEPTIONS_HPP
+#define GUARDFW_EXCEPTIONS_HPP
+
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+namespace GuardFW
+{
+
+class WrapperError : public std::system_error
+{
+public:
+	WrapperError(int error, const std::string_view& wrapped_function_name, const std::source_location& location)
+	: system_error(error, std::system_category(), build_what(error, wrapped_function_name, location))
+	{}
+
+private:
+	static std::string build_what(
+		int error, const std::string_view& wrapped_function_name, const std::source_location& location
+	);
+};
+
+}  //  namespace GuardFW
+
+#endif	// GUARDFW_EXCEPTIONS_HPP

--- a/src/guardfw/file_descriptor.hpp
+++ b/src/guardfw/file_descriptor.hpp
@@ -1,10 +1,14 @@
-/*
-* guardfw/file_descriptor.hpp
-*
-* (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
-*
-* This file is distributed under the MIT license, see file LICENSE.
-*/
+/**
+ * Type definition for file descriptors.
+ *
+ * POSIX file descriptors are defined as 'int', but as this is ambiguous for reading,
+ * so 'FileDescriptor' will be used. Additionally POSIX message queues are using int (=mqd_t)
+ * as descriptors, which will also be referenced as 'FileDescriptor' by this library.
+ *
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
+ */
 
 #pragma once
 #ifndef GUARDFW_FILE_DESCRIPTOR_HPP

--- a/src/guardfw/guard_event.hpp
+++ b/src/guardfw/guard_event.hpp
@@ -1,9 +1,13 @@
-/*
- * guardfw/guard_event.hpp
+/**
+ * Guard class for wrapping the file descriptor of eventfd kernel objects and providung an API.
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * A guard class encapsulates the handle for a kernel object (here for eventfd events).
+ * This derived class provides opening and closing in constructor & destructor
+ * and the rest of the API as member functions.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once

--- a/src/guardfw/guard_file.hpp
+++ b/src/guardfw/guard_file.hpp
@@ -1,0 +1,169 @@
+/**
+ * Guard class for wrapping the file descriptor of file kernel objects and providung an API.
+ *
+ * A guard class encapsulates the handle for a kernel object (here files on the file system).
+ * This derived class provides opening and closing in constructor & destructor
+ * and the rest of the API as member functions.
+ *
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
+ */
+
+#pragma once
+#ifndef GUARDFW_GUARD_FILE_HPP
+#define GUARDFW_GUARD_FILE_HPP
+
+#include <fcntl.h>	// O_ macros
+
+#include <optional>
+
+#include <guardfw/guard.hpp>
+#include <guardfw/file_descriptor.hpp>
+
+namespace GuardFW
+{
+
+class GuardFile : Guard<FileDescriptor, file_descriptor_invalid>
+{
+public:
+	using Flags = TypeGuard<int>;
+	using Mode = TypeGuard<mode_t>;
+
+	/**
+	 * Constructor wrapper for ::open() without mode parameter
+	 * @param pathname        see 'man 2 open'
+	 * @param flag            sse 'man 2 open'
+	 * @param source_location calling location, used in case of an exceotion
+	 */
+	explicit GuardFile(
+		const char* pathname,  // see 'man 2 open'
+		Flags flags,		   // see 'man 2 open'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	/**
+	 * Constructor wrapper for ::open() with mode parameter
+	 * @param pathname        see 'man 2 open'
+	 * @param flags           see 'man 2 open'
+	 * @param mode            see 'man 2 open'
+	 * @param source_location calling location, used in case of an exceotion
+	 */
+	explicit GuardFile(
+		const char* pathname,  // see 'man 2 open'
+		Flags flags,		   // see 'man 2 open'
+		Mode mode,			   // see 'man 2 open'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	/**
+	 * Constructor wrapper for ::creat() with mode parameter
+	 * @param pathname        see 'man 2 open'
+	 * @param mode            see 'man 2 open'
+	 * @param source_location calling location, used in case of an exceotion
+	 */
+	explicit GuardFile(
+		const char* pathname,  // see 'man 2 open'
+		Mode mode,			   // see 'man 2 open'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	/**
+	 * Constructor wrapper for ::openat() without mode parameter
+	 * @param dirfd           see 'man 2 open'
+	 * @param pathname        see 'man 2 open'
+	 * @param flags           see 'man 2 open'
+	 * @param source_location calling location, used in case of an exceotion
+	 */
+	explicit GuardFile(
+		FileDescriptor dirfd,  // see 'man 2 open'
+		const char* pathname,  // see 'man 2 open'
+		Flags flags,		   // see 'man 2 open'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	/**
+	 * Constructor wrapper for ::openat() with mode parameter
+	 * @param dirfd           see 'man 2 open'
+	 * @param pathname        see 'man 2 open'
+	 * @param flags           see 'man 2 open'
+	 * @param mode            see 'man 2 open'
+	 * @param source_location calling location, used in case of an exceotion
+	 */
+	explicit GuardFile(
+		FileDescriptor dirfd,  // see 'man 2 open'
+		const char* pathname,  // see 'man 2 open'
+		Flags flags,		   // see 'man 2 open'
+		Mode mode,			   // see 'man 2 open'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	/// Destructor wrapper for ::close()
+	virtual ~GuardFile() override;
+
+	/**
+	 * Wrapper for ::ioctl without return value
+	 * @param request         // see 'man 2 ioctl'
+	 * @param ptr             // see 'man 2 ioctl'
+	 * @param source_location calling location, used in case of an exceotion
+	 */
+	void ioctl_noretval(
+		unsigned long request,	// see 'man 2 ioctl'
+		void* ptr,				// see 'man 2 ioctl'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	/**
+	 * Wrapper for ::ioctl with return value
+	 * @param request         // see 'man 2 ioctl'
+	 * @param ptr             // see 'man 2 ioctl'
+	 * @param source_location calling location, used in case of an exceotion
+	 */
+	[[nodiscard]] int ioctl_retval(
+		unsigned long request,	// see 'man 2 ioctl'
+		void* ptr,				// see 'man 2 ioctl'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	[[nodiscard]] size_t read(
+		void* buf,	   // see 'man 2 read'
+		size_t count,  // see 'man 2 read'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	[[nodiscard]] std::optional<size_t> read_nonblock(
+		void* buf,	   // see 'man 2 read'
+		size_t count,  // see 'man 2 read'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	[[nodiscard]] size_t write(
+		void* buf,	   // see 'man 2 write'
+		size_t count,  // see 'man 2 write'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	[[nodiscard]] std::optional<size_t> write_nonblock(
+		void* buf,	   // see 'man 2 write'
+		size_t count,  // see 'man 2 write'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	void syncfs(const std::source_location& source_location = std::source_location::current());
+
+	[[nodiscard]] off_t lseek(
+		off_t offset,  // see 'man 2 lseek'
+		int whence,	   // see 'man 2 lseek'
+		const std::source_location& source_location = std::source_location::current()
+	);
+
+	[[nodiscard]] off64_t lseek64(
+		off64_t offset,	 // see 'man 3 lseek64'
+		int whence,		 // see 'man 3 lseek64'
+		const std::source_location& source_location = std::source_location::current()
+	);
+};
+
+}  // namespace GuardFW
+
+#endif	// GUARDFW_GUARD_FILE_HPP

--- a/src/guardfw/guard_timer.hpp
+++ b/src/guardfw/guard_timer.hpp
@@ -1,9 +1,13 @@
-/*
- * guardfw/guard_timer.hpp
+/**
+ * Guard class for wrapping the file descriptor of timerfd kernel objects and providung an API.
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * A guard class encapsulates the handle for a kernel object (here for timerfd timers).
+ * This derived class provides opening and closing in constructor & destructor
+ * and the rest of the API as member functions.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once

--- a/src/guardfw/traits.hpp
+++ b/src/guardfw/traits.hpp
@@ -1,9 +1,13 @@
-/*
- * guardfw/traits.hpp
+/**
+ * Type traits collection for GuardFW.
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * POSIX file descriptors are defined as 'int', but as this is ambiguous for reading,
+ * so 'FileDescriptor' will be used. Additionally POSIX message queues are using int (=mqd_t)
+ * as descriptors, which will also be referenced as 'FileDescriptor' by this library.
  *
- * This file is distributed under the ISC license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once
@@ -54,6 +58,7 @@ using ReturnType = decltype(return_type(FUNCTION_POINTER));
 template<auto FUNCTION_POINTER>
 consteval static std::string_view name_of()
 {
+	// TODO: add type check for FUNCTION_POINTER
 	const char* start = __PRETTY_FUNCTION__;  // reads FUNCTION_POINTER as part of full function name
 	while (*start != '\0' && *start != '=')
 		start++;
@@ -64,7 +69,7 @@ consteval static std::string_view name_of()
 	const char* end = start;
 	while (*end != '\0' && *end != ';')
 		end++;
-	return std::string_view(start, end - start);
+	return std::string_view(start, static_cast<size_t>(end - start));
 }
 
 }  //  namespace GuardFW

--- a/src/guardfw/version.hpp
+++ b/src/guardfw/version.hpp
@@ -1,9 +1,12 @@
-/*
- * guardfw/version.hpp
+/**
+ * Helper class for providing the library version number.
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * The class needs access to a generated version header file,
+ * which contains the cmake project version number.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once

--- a/src/guardfw/wrapped_eventfd.hpp
+++ b/src/guardfw/wrapped_eventfd.hpp
@@ -1,9 +1,12 @@
-/*
- * guardfw/wrapped_eventfd.hpp
+/**
+ * Wrappers for system header sys/eventfd.h
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * This is a convenience header for encapsulating ugly wrapper<>() calls to Linux API and POSIX functions
+ * to nice looking calls with the same or similar name & API, but separate error handling.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once
@@ -11,12 +14,14 @@
 #define GUARDFW_WRAPPED_EVENTFD_HPP
 
 #include <sys/eventfd.h>
+
 #include <guardfw/wrapper.hpp>
+#include <guardfw/file_descriptor.hpp>
 
 namespace GuardFW
 {
 
-[[nodiscard]] inline static int eventfd(
+[[nodiscard]] inline static FileDescriptor eventfd(
 	unsigned int initval, int flags, const std::source_location& source_location = std::source_location::current()
 )
 {

--- a/src/guardfw/wrapped_fnctl.hpp
+++ b/src/guardfw/wrapped_fnctl.hpp
@@ -1,9 +1,12 @@
-/*
- * guardfw/wrapped_fnctl.hpp
+/**
+ * Wrappers for system header fcntl.h
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * This is a convenience header for encapsulating ugly wrapper<>() calls to Linux API and POSIX functions
+ * to nice looking calls with the same or similar name & API, but separate error handling.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once
@@ -11,54 +14,56 @@
 #define GUARDFW_WRAPPED_FNCTL_HPP
 
 #include <fcntl.h>
-#include <guardfw/context_posix.hpp>
+
+#include <guardfw/wrapper.hpp>
+#include <guardfw/file_descriptor.hpp>
 
 namespace GuardFW
 {
 
-[[nodiscard]] inline static int open(
+[[nodiscard]] inline static FileDescriptor open(
 	const char* pathname, int flags, const std::source_location& source_location = std::source_location::current()
 )
 {
-	return ContextPosix_RepeatEINTR::wrapper<::open>(source_location, pathname, flags);
+	return ContextRepeatEINTR::wrapper<::open>(source_location, pathname, flags);
 }
 
-[[nodiscard]] inline static int open(
+[[nodiscard]] inline static FileDescriptor open(
 	const char* pathname,
 	int flags,
 	mode_t mode,
 	const std::source_location& source_location = std::source_location::current()
 )
 {
-	return ContextPosix_RepeatEINTR::wrapper<::open>(source_location, pathname, flags, mode);
+	return ContextRepeatEINTR::wrapper<::open>(source_location, pathname, flags, mode);
 }
 
-[[nodiscard]] inline static int creat(
+[[nodiscard]] inline static FileDescriptor creat(
 	const char* pathname, mode_t mode, const std::source_location& source_location = std::source_location::current()
 )
 {
-	return ContextPosix_RepeatEINTR::wrapper<::creat>(source_location, pathname, mode);
+	return ContextRepeatEINTR::wrapper<::creat>(source_location, pathname, mode);
 }
 
-[[nodiscard]] inline static int openat(
-	int dirfd,
+[[nodiscard]] inline static FileDescriptor openat(
+	FileDescriptor dirfd,
 	const char* pathname,
 	int flags,
 	const std::source_location& source_location = std::source_location::current()
 )
 {
-	return ContextPosix_RepeatEINTR::wrapper<::openat>(source_location, dirfd, pathname, flags);
+	return ContextRepeatEINTR::wrapper<::openat>(source_location, dirfd, pathname, flags);
 }
 
-[[nodiscard]] inline static int openat(
-	int dirfd,
+[[nodiscard]] inline static FileDescriptor openat(
+	FileDescriptor dirfd,
 	const char* pathname,
 	int flags,
 	mode_t mode,
 	const std::source_location& source_location = std::source_location::current()
 )
 {
-	return ContextPosix_RepeatEINTR::wrapper<::openat>(source_location, dirfd, pathname, flags, mode);
+	return ContextRepeatEINTR::wrapper<::openat>(source_location, dirfd, pathname, flags, mode);
 }
 
 }  // namespace GuardFW

--- a/src/guardfw/wrapped_ioctl.hpp
+++ b/src/guardfw/wrapped_ioctl.hpp
@@ -1,9 +1,12 @@
-/*
- * guardfw/wrapped_ioctl.hpp
+/**
+ * Wrappers for system header sys/ioctl.h
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * This is a convenience header for encapsulating ugly wrapper<>() calls to Linux API and POSIX functions
+ * to nice looking calls with the same or similar name & API, but separate error handling.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once
@@ -11,22 +14,28 @@
 #define GUARDFW_WRAPPED_IOCTL_HPP
 
 #include <sys/ioctl.h>
+
 #include <guardfw/wrapper.hpp>
+#include <guardfw/file_descriptor.hpp>
 
 namespace GuardFW
 {
 
-template<typename T>
-inline static void ioctl(
-	int fd, unsigned long request, T* ptr, const std::source_location& source_location = std::source_location::current()
+inline static void ioctl_noretval(
+	FileDescriptor fd,
+	unsigned long request,
+	void* ptr,
+	const std::source_location& source_location = std::source_location::current()
 )
 {
 	ContextStd::wrapper<::ioctl, void>(source_location, fd, request, ptr);
 }
 
-template<typename T>
 [[nodiscard]] inline static int ioctl_retval(
-	int fd, unsigned long request, T* ptr, const std::source_location& source_location = std::source_location::current()
+	FileDescriptor fd,
+	unsigned long request,
+	void* ptr,
+	const std::source_location& source_location = std::source_location::current()
 )
 {
 	return ContextStd::wrapper<::ioctl>(source_location, fd, request, ptr);

--- a/src/guardfw/wrapped_mqueue.hpp
+++ b/src/guardfw/wrapped_mqueue.hpp
@@ -1,9 +1,12 @@
-/*
- * guardfw/wrapped_mqueue.hpp
+/**
+ * Wrappers for system header mqueue.h
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * This is a convenience header for encapsulating ugly wrapper<>() calls to Linux API and POSIX functions
+ * to nice looking calls with the same or similar name & API, but separate error handling.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once
@@ -11,6 +14,7 @@
 #define GUARDFW_WRAPPED_MQUEUE_HPP
 
 #include <mqueue.h>
+
 #include <guardfw/context_posix.hpp>
 
 namespace GuardFW

--- a/src/guardfw/wrapped_signalfd.hpp
+++ b/src/guardfw/wrapped_signalfd.hpp
@@ -1,9 +1,12 @@
-/*
- * guardfw/wrapped_signalfd.hpp
+/**
+ * Wrappers for system header sys/signalfd.h
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * This is a convenience header for encapsulating ugly wrapper<>() calls to Linux API and POSIX functions
+ * to nice looking calls with the same or similar name & API, but separate error handling.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once
@@ -11,6 +14,7 @@
 #define GUARDFW_WRAPPED_SIGNALFD_HPP
 
 #include <sys/signalfd.h>
+
 #include <guardfw/context_posix.hpp>
 
 namespace GuardFW

--- a/src/guardfw/wrapped_socket.hpp
+++ b/src/guardfw/wrapped_socket.hpp
@@ -1,9 +1,12 @@
-/*
- * guardfw/wrapped_socketl.hpp
+/**
+ * Wrappers for system header sys/socket.h
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * This is a convenience header for encapsulating ugly wrapper<>() calls to Linux API and POSIX functions
+ * to nice looking calls with the same or similar name & API, but separate error handling.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once
@@ -15,7 +18,9 @@
 #endif
 
 #include <sys/socket.h>
+
 #include <cstddef>
+
 #include <guardfw/context_posix.hpp>
 
 namespace GuardFW

--- a/src/guardfw/wrapped_timerfd.hpp
+++ b/src/guardfw/wrapped_timerfd.hpp
@@ -1,9 +1,12 @@
-/*
- * guardfw/wrapped_timerfd.hpp
+/**
+ * Wrappers for system header sys/timerfd.h
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * This is a convenience header for encapsulating ugly wrapper<>() calls to Linux API and POSIX functions
+ * to nice looking calls with the same or similar name & API, but separate error handling.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once

--- a/src/guardfw/wrapped_unistd.hpp
+++ b/src/guardfw/wrapped_unistd.hpp
@@ -1,31 +1,50 @@
-/*
- * guardfw/wrapped_unistd.hpp
+/**
+ * Wrappers for system header unistd.h
  *
- * (C) 2022-2023 by Simon Gleissner <simon@gleissner.de>
+ * This is a convenience header for encapsulating ugly wrapper<>() calls to Linux API and POSIX functions
+ * to nice looking calls with the same or similar name & API, but separate error handling.
  *
- * This file is distributed under the MIT license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #pragma once
 #ifndef GUARDFW_WRAPPED_UNISTD_HPP
 #define GUARDFW_WRAPPED_UNISTD_HPP
 
+#ifndef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE
+#endif
+
 #include <unistd.h>
+#include <sys/types.h>
+
 #include <cstddef>
+
 #include <guardfw/wrapper.hpp>
+#include <guardfw/file_descriptor.hpp>
 
 namespace GuardFW
 {
 
+// read
+
 [[nodiscard]] inline static size_t read(
-	int fd, void* buf, size_t count, const std::source_location& source_location = std::source_location::current()
+	FileDescriptor fd,
+	void* buf,
+	size_t count,
+	const std::source_location& source_location = std::source_location::current()
 )
 {
 	return ContextRepeatEINTR::wrapper<::read, size_t>(source_location, fd, buf, count);
 }
 
 [[nodiscard]] inline static std::optional<size_t> read_nonblock(
-	int fd, void* buf, size_t count, const std::source_location& source_location = std::source_location::current()
+	FileDescriptor fd,
+	void* buf,
+	size_t count,
+	const std::source_location& source_location = std::source_location::current()
 )
 {
 	return ContextNonblockRepeatEINTR::wrapper<::read, size_t>(source_location, fd, buf, count);
@@ -33,14 +52,22 @@ namespace GuardFW
 
 // used for eventfd
 [[nodiscard]] inline static bool read_nonblock_ignore_result(
-	int fd, void* buf, size_t count, const std::source_location& source_location = std::source_location::current()
+	FileDescriptor fd,
+	void* buf,
+	size_t count,
+	const std::source_location& source_location = std::source_location::current()
 )
 {
 	return ContextNonblockRepeatEINTR::wrapper<::read, void>(source_location, fd, buf, count);
 }
 
+// write
+
 [[nodiscard]] inline static size_t write(
-	int fd, void* buf, size_t count, const std::source_location& source_location = std::source_location::current()
+	FileDescriptor fd,
+	void* buf,
+	size_t count,
+	const std::source_location& source_location = std::source_location::current()
 )
 {
 	return ContextRepeatEINTR::wrapper<::write, size_t>(source_location, fd, buf, count);
@@ -48,43 +75,60 @@ namespace GuardFW
 
 // used for eventfd
 [[nodiscard]] inline static std::optional<size_t> write_nonblock(
-	int fd, void* buf, size_t count, const std::source_location& source_location = std::source_location::current()
+	FileDescriptor fd,
+	void* buf,
+	size_t count,
+	const std::source_location& source_location = std::source_location::current()
 )
 {
 	return ContextNonblockRepeatEINTR::wrapper<::write, size_t>(source_location, fd, buf, count);
 }
 
 inline void write_ignore_result(
-	int fd, void* buf, size_t count, const std::source_location& source_location = std::source_location::current()
+	FileDescriptor fd,
+	void* buf,
+	size_t count,
+	const std::source_location& source_location = std::source_location::current()
 )
 {
 	return ContextRepeatEINTR::wrapper<::write, void>(source_location, fd, buf, count);
 }
 
-inline static void close(int fd, const std::source_location& source_location = std::source_location::current())
+// close
+
+// Ignores EINTR, throws all other errors
+inline static void close(
+	FileDescriptor fd, const std::source_location& source_location = std::source_location::current()
+)
 {
-	ContextStd::wrapper<::close, void>(source_location, fd);
+	ContextIgnoreEintr::wrapper<::close, void>(source_location, fd);
 }
 
-[[nodiscard]] inline static Error close_direct_errors(
-	int fd, const std::source_location& source_location = std::source_location::current()
-) noexcept
+// sync
+
+// void ::sync() currently not handled, as it needs no wrapper
+
+inline static void syncfs(
+	FileDescriptor fd, const std::source_location& source_location = std::source_location::current()
+)
 {
-	return ContextDirectErrors::wrapper<::close, void>(source_location, fd);
+	ContextStd::wrapper<::syncfs, void>(source_location, fd);
 }
 
-inline static void close_ignore_errors(
-	int fd, const std::source_location& source_location = std::source_location::current()
-) noexcept
+// lseek
+
+[[nodiscard]] inline static off_t lseek(
+	int fd, off_t offset, int whence, const std::source_location& source_location = std::source_location::current()
+)
 {
-	ContextIgnoreErrors::wrapper<::close, void>(source_location, fd);
+	return ContextStd::wrapper<::lseek>(source_location, fd, offset, whence);
 }
 
-inline static void close_ignore_eintr(
-	int fd, const std::source_location& source_location = std::source_location::current()
-) noexcept
+[[nodiscard]] inline static off64_t lseek64(
+	int fd, off64_t offset, int whence, const std::source_location& source_location = std::source_location::current()
+)
 {
-	static_cast<void>(ContextSoftEintr::wrapper<::close, void>(source_location, fd));
+	return ContextStd::wrapper<::lseek64>(source_location, fd, offset, whence);
 }
 
 }  // namespace GuardFW

--- a/src/tests/test_file.cpp
+++ b/src/tests/test_file.cpp
@@ -1,0 +1,22 @@
+/**
+ * Catch2 unit tests for guardfw/guard_file.hpp/cpp
+ *
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <guardfw/guard_file.hpp>
+
+bool test_file(const char* filename)
+{
+	GuardFW::GuardFile file(filename, GuardFW::GuardFile::Flags(O_RDONLY));
+	return true;
+}
+
+TEST_CASE("file: open, read, close", "[file]")
+{
+	CHECK_NOTHROW(test_file("/proc/meminfo"));
+}

--- a/src/tests/test_version.cpp
+++ b/src/tests/test_version.cpp
@@ -1,9 +1,9 @@
-/*
- * tests/test_version.cpp
+/**
+ * Catch2 unit tests for guardfw/version.hpp
  *
- * (C) 2017-2022 by Simon Gleissner <simon@gleissner.de>, http://concurrentfw.de
- *
- * This file is distributed under the ISC license, see file LICENSE.
+ * @author    Simon Gleissner <simon@gleissner.de>, http://guardfw.de
+ * @copyright MIT license, see file LICENSE
+ * @file
  */
 
 #include <catch2/catch_test_macros.hpp>
@@ -13,11 +13,13 @@
 TEST_CASE("version number", "[version]")
 {
 	INFO(
-		"version: " << GuardFW::Version::MAJOR << "." << GuardFW::Version::MINOR << "." << GuardFW::Version::PATCH
-					<< "." << GuardFW::Version::PATCH
+		"version: " << GuardFW::Version::MAJOR << "."  //
+					<< GuardFW::Version::MINOR << "."  //
+					<< GuardFW::Version::PATCH << "."  //
+					<< GuardFW::Version::PATCH		   //
 	);
-	CHECK(GuardFW::Version::MAJOR == 0);
-	CHECK(GuardFW::Version::MINOR == 0);
-	CHECK(GuardFW::Version::PATCH == 1);
+	CHECK(GuardFW::Version::MAJOR == 0);  // must be manually changed on each
+	CHECK(GuardFW::Version::MINOR == 0);  // version change in CMakeLists.txt
+	CHECK(GuardFW::Version::PATCH == 2);
 	//	CHECK(GuardFW::Version::TWEAK == 0);
 }


### PR DESCRIPTION
- separate exception class for wrapper
- new Doxygen header
- wrapper: allow ignoring soft errors
- rework Guard base class
- add TypeGuard helper class for guards
- new guard for files
- use FileDescriptor type for int file descriptors
- refactor ioctl wrapper
- refactor close wrapper & context
- refactor wrapper Catch2 test code